### PR TITLE
Datasource wrapper for blob string

### DIFF
--- a/src/main/java/com/tri_tail/jaxb2_marshalling/ByteArrayDataSource.java
+++ b/src/main/java/com/tri_tail/jaxb2_marshalling/ByteArrayDataSource.java
@@ -1,0 +1,37 @@
+package com.tri_tail.jaxb2_marshalling;
+
+
+import jakarta.activation.DataSource;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ByteArrayDataSource implements DataSource {
+  private byte[] data;
+  private String type;
+
+  public ByteArrayDataSource(byte[] data, String type) {
+    this.data = data; this.type = type;
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return new ByteArrayInputStream(data);
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    throw new IOException("Not Supported");
+  }
+
+  @Override
+  public String getContentType() {
+    return type;
+  }
+
+  @Override
+  public String getName() {
+    return "ByteArrayDataSource";
+  }
+}

--- a/src/main/java/com/tri_tail/jaxb2_marshalling/Jaxb2MarshallerConfig.java
+++ b/src/main/java/com/tri_tail/jaxb2_marshalling/Jaxb2MarshallerConfig.java
@@ -11,7 +11,7 @@ public class Jaxb2MarshallerConfig {
     public Jaxb2Marshaller myMarshaller() {
         Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
         marshaller.setContextPath("com.tri_tail.jaxb2_marshalling.generated");
-        marshaller.setMtomEnabled(true); 
+        marshaller.setMtomEnabled(false);
         return marshaller;
     }
 }

--- a/src/main/java/com/tri_tail/jaxb2_marshalling/MySoapClient.java
+++ b/src/main/java/com/tri_tail/jaxb2_marshalling/MySoapClient.java
@@ -1,5 +1,6 @@
 package com.tri_tail.jaxb2_marshalling;
 
+import jakarta.activation.DataSource;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.stereotype.Component;
 import org.springframework.ws.client.core.WebServiceTemplate;
@@ -28,7 +29,9 @@ public class MySoapClient extends WebServiceGatewaySupport {
 
     public void sendDocuments(BlobRequest blobRequest) {
         var binaryData = new BinaryData();
-        DataHandler dataHandler = new DataHandler(blobRequest.getBlob(), "application/pdf");
+        //DataHandler dataHandler = new DataHandler(blobRequest.getBlob(), "application/pdf");
+        DataSource ds = new ByteArrayDataSource(blobRequest.getBlob().getBytes(), "application/pdf");
+        DataHandler dataHandler = new DataHandler(ds);
         binaryData.setBlob(dataHandler);
         binaryData.setExtension(blobRequest.getExtension());
         var soapRequest = new MySoapRequest();

--- a/src/test/java/com/tri_tail/jaxb2_marshalling/MySoapClientTest.java
+++ b/src/test/java/com/tri_tail/jaxb2_marshalling/MySoapClientTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,9 @@ public class MySoapClientTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         request.writeTo(out);
         String soapMessageString = out.toString(StandardCharsets.UTF_8.name());
-        assertThat(soapMessageString).contains("<blob>123456789ABCDEF0</blob>");
+        // Base64 encoding of "123456789ABCDEF0"
+        String expectedBase64 = Base64.getEncoder().encodeToString(blobRequest.getBlob().getBytes(
+            StandardCharsets.UTF_8));
+        assertThat(soapMessageString).contains(String.format("<blob>%s</blob>", expectedBase64));
     }
 }


### PR DESCRIPTION
 - add a BinaryDataSource wrapper for blob
 - modify DataHandler initialization in client to accept above BinaryDataSource
 - modify test to compare with encoded data
 - disable mtom to accept as inline data instead of attachment